### PR TITLE
fix the name for the spec

### DIFF
--- a/src/sexec.erl
+++ b/src/sexec.erl
@@ -20,7 +20,7 @@
 
 -record(state, {name, opts, pids}).
 
--type sproc() :: {sexec, string()} | {sexec, atom()}.
+-type sproc() :: term().
 
 %%%%%%%%%%%
 %%% API %%%


### PR DESCRIPTION
The name can be any thing since the macro handle the prefix.